### PR TITLE
feat: Implement missing server address failure scenario

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ WORKDIR /app
 
 COPY . .
 
-RUN dotnet tool install Nuke.GlobalTool --global
+RUN dotnet tool install Nuke.GlobalTool --global --version 9.0.4 
 RUN export PATH="$PATH:/root/.dotnet/tools" && nuke Publish --configuration Release --skip UnitTests E2ETests Format
 
 FROM mcr.microsoft.com/dotnet/aspnet:9.0

--- a/src/ZtrBoardGame.Console/Commands/Board/BoardGameService.cs
+++ b/src/ZtrBoardGame.Console/Commands/Board/BoardGameService.cs
@@ -1,0 +1,100 @@
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Spectre.Console;
+using System;
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using ZtrBoardGame.Configuration.Shared;
+using ZtrBoardGame.Console.Infrastructure;
+
+namespace ZtrBoardGame.Console.Commands.Board;
+
+public class BoardGameService(IBoardGameStatusStorage boardGameStatusStorage, IHttpClientFactory httpClientFactory, IAnsiConsole console, IOptions<BoardNetworkSettings> serverAddressProvider, ILogger<BoardGameService> logger) : IHostedService
+{
+    private static readonly ResilienceSettings ResilienceSettings = new(10, TimeSpan.FromSeconds(1), "Announce Presence", "the server");
+    Task _backgroundTask;
+
+    public async Task MainGameLoop(CancellationToken cancellationToken)
+    {
+        do
+        {
+            await SingleGame(cancellationToken);
+        } while (!cancellationToken.IsCancellationRequested);
+    }
+
+    async Task SingleGame(CancellationToken cancellationToken)
+    {
+        await WaitGameToBegin();
+
+        var delay = await ActualGameLoop();
+
+        await FinishTheGame(cancellationToken, delay);
+    }
+
+    static async Task<TimeSpan> ActualGameLoop()
+    {
+        var delay = TimeSpan.FromSeconds(Random.Shared.Next(10, 30));
+        await Task.Delay(delay);
+        return delay;
+    }
+
+    async Task WaitGameToBegin()
+    {
+        do
+        {
+            AnsiConsole.MarkupLine("[yellow]Czekanie na rozpoczęcie gry...[/]");
+            await Task.Delay(TimeSpan.FromSeconds(2));
+        } while (!boardGameStatusStorage.StartGameRequested);
+
+        AnsiConsole.MarkupLine("[green]Gra rozpoczęta![/]");
+
+    }
+
+    async Task FinishTheGame(CancellationToken cancellationToken, TimeSpan delay)
+    {
+        AnsiConsole.MarkupLine("[green]Gra zakończona![/]");
+
+        var httpClient = httpClientFactory.CreateClient(BoardHttpClientConfigure.ToPcClientName);
+
+        using var _ = logger.BeginScopeWith(("PcServerAddress", httpClient.BaseAddress?.ToString() ?? "<NULL>"));
+
+        await ResilienceHelper.InvokeWithRetryAsync(async () =>
+        {
+            await SendResults(cancellationToken, delay, httpClient);
+        }, ResilienceSettings, console, logger, cancellationToken, httpClient.BaseAddress);
+
+        boardGameStatusStorage.StartGameRequested = false;
+    }
+
+    async Task SendResults(CancellationToken cancellationToken, TimeSpan delay, HttpClient httpClient)
+    {
+        if (string.IsNullOrWhiteSpace(serverAddressProvider.Value.BoardAddress))
+        {
+            logger.LogWarning("Local server address is not set. Cannot announce presence to PC server.");
+            throw new InvalidOperationException("Local server address is not set");
+        }
+
+        var urlEncode = WebUtility.UrlEncode(serverAddressProvider.Value.BoardAddress);
+        var resultEncoded = WebUtility.UrlEncode(delay.ToString());
+        var response = await httpClient.PostAsync(
+            $"/api/boards/game/status?responseAddress={urlEncode}&result={resultEncoded}", null,
+            cancellationToken);
+        response.EnsureSuccessStatusCode();
+        console.MarkupLine($"[green]Results sent to the server[/]");
+        logger.LogInformation("Successfully sent results to the server");
+    }
+
+    public Task StartAsync(CancellationToken cancellationToken)
+    {
+        _backgroundTask = MainGameLoop(cancellationToken);
+        return Task.CompletedTask;
+    }
+
+    public async Task StopAsync(CancellationToken cancellationToken)
+    {
+        await _backgroundTask;
+    }
+}

--- a/src/ZtrBoardGame.Console/Commands/Board/BoardGameStatusStorage.cs
+++ b/src/ZtrBoardGame.Console/Commands/Board/BoardGameStatusStorage.cs
@@ -1,0 +1,11 @@
+namespace ZtrBoardGame.Console.Commands.Board;
+
+public interface IBoardGameStatusStorage
+{
+    public bool StartGameRequested { get; set; }
+}
+
+public class BoardGameStatusStorage : IBoardGameStatusStorage
+{
+    public bool StartGameRequested { get; set; }
+}

--- a/src/ZtrBoardGame.Console/Commands/Board/BoardRunCommand.cs
+++ b/src/ZtrBoardGame.Console/Commands/Board/BoardRunCommand.cs
@@ -15,15 +15,8 @@ public class BoardRunSettings : CommandSettings
 {
 }
 
-public class BoardRunCommand : CancellableAsyncCommand<BoardRunSettings>
+public class BoardRunCommand(TypeRegistrar typeRegistrar) : CancellableAsyncCommand<BoardRunSettings>
 {
-    readonly TypeRegistrar _typeRegistrar;
-
-    public BoardRunCommand(TypeRegistrar typeRegistrar)
-    {
-        _typeRegistrar = typeRegistrar;
-    }
-
     public override async Task<int> ExecuteAsync(CommandContext context, BoardRunSettings runSettings, CancellationToken cancellationToken)
     {
         try
@@ -41,12 +34,14 @@ public class BoardRunCommand : CancellableAsyncCommand<BoardRunSettings>
     async Task<int> RunWebServer(CommandContext context, CancellationToken cancellationToken)
     {
         var builder = WebApplication.CreateBuilder(context.Arguments.ToArray());
-        foreach (var copyOfService in _typeRegistrar.GetCopyOfServices())
+        foreach (var copyOfService in typeRegistrar.GetCopyOfServices())
         {
             builder.Services.Add(copyOfService);
         }
 
         builder.Services.AddSingleton<IHostedService, HelloService>();
+        builder.Services.AddSingleton<IHostedService, BoardGameService>();
+        builder.Services.AddSingleton<IBoardGameStatusStorage, BoardGameStatusStorage>();
         builder.Services.AddControllers();
         builder.Services.AddHttpClient();
         builder.Services.Configure<ForwardedHeadersOptions>(options =>

--- a/src/ZtrBoardGame.Console/Commands/Board/GameController.cs
+++ b/src/ZtrBoardGame.Console/Commands/Board/GameController.cs
@@ -1,0 +1,14 @@
+using Microsoft.AspNetCore.Mvc;
+
+namespace ZtrBoardGame.Console.Commands.Board;
+
+[ApiController, Route("api/board/game")]
+public class GameController(IBoardGameStatusStorage boardGameStatusStorage) : ControllerBase
+{
+    [HttpPost]
+    public IActionResult Post()
+    {
+        boardGameStatusStorage.StartGameRequested = true;
+        return Ok();
+    }
+}

--- a/src/ZtrBoardGame.Console/Commands/PC/GameService.cs
+++ b/src/ZtrBoardGame.Console/Commands/PC/GameService.cs
@@ -1,0 +1,74 @@
+using Microsoft.Extensions.Logging;
+using Spectre.Console;
+using System;
+using System.Collections.Concurrent;
+using System.Linq;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using ZtrBoardGame.Console.Infrastructure;
+
+namespace ZtrBoardGame.Console.Commands.PC;
+
+public record Board(Uri Address);
+public record GameResult(TimeSpan Duration);
+
+public interface IGameService
+{
+    Task StartSessionAsync(CancellationToken cancellationToken);
+    void RecordResults(Board board, GameResult result);
+}
+
+public class GameService(IBoardStorage boardStorage, IAnsiConsole console, IHttpClientFactory httpClientFactory, ILogger<GameService> logger) : IGameService
+{
+    readonly ConcurrentDictionary<Board, GameResult> _results = new();
+    private static readonly ResilienceSettings ResilienceSettings = new(10, TimeSpan.FromSeconds(1), "Check Presence", "the board");
+
+    public void RecordResults(Board board, GameResult result)
+    {
+        console.MarkupLine($"Received game status from board: {board.Address}");
+        _results.TryAdd(board, result);
+    }
+
+    public async Task StartSessionAsync(CancellationToken cancellationToken)
+    {
+        foreach (var boardAddress in boardStorage.GetAllAddresses())
+        {
+            var httpClient = httpClientFactory.CreateClient();
+            using var _ = logger.BeginScopeWith(("BoardAddress", boardAddress.ToString()));
+
+            await ResilienceHelper.InvokeWithRetryAsync(async () =>
+            {
+                var response = await httpClient.PostAsync(new Uri(boardAddress, "api/board/game"), null, cancellationToken);
+                response.EnsureSuccessStatusCode();
+                logger.LogInformation("Successfully checked connection to Board");
+            }, ResilienceSettings, console, logger, cancellationToken, boardAddress);
+        }
+
+        do
+        {
+            AnsiConsole.MarkupLine($"[grey]Oczekiwanie na wyniki od graczy[/]");
+            await Task.Delay(TimeSpan.FromSeconds(5), cancellationToken);
+        } while (_results.Count != boardStorage.Count);
+
+        var sorted = _results.OrderBy(kv => kv.Value.Duration).ToList();
+
+        var table = new Table()
+            .RoundedBorder()
+            .AddColumn("Miejsce")
+            .AddColumn("Board")
+            .AddColumn("Czas");
+
+        var place = 1;
+        foreach (var kv in sorted)
+        {
+            var board = kv.Key;
+            var result = kv.Value;
+            table.AddRow(place.ToString(), board.Address.ToString(), result.Duration.ToString(@"hh\:mm\:ss"));
+            place++;
+        }
+
+        AnsiConsole.Write(new FigletText("Wyniki"));
+        AnsiConsole.Write(table);
+    }
+}

--- a/src/ZtrBoardGame.Console/Commands/PC/PcRunCommand.cs
+++ b/src/ZtrBoardGame.Console/Commands/PC/PcRunCommand.cs
@@ -3,6 +3,7 @@ using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.HttpOverrides;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
+using Spectre.Console;
 using Spectre.Console.Cli;
 using System.Linq;
 using System.Threading;
@@ -14,22 +15,93 @@ namespace ZtrBoardGame.Console.Commands.PC;
 
 public class PcRunSettings : CommandSettings
 {
+    [CommandOption("--non-interactive")]
+    public bool NonInteractive { get; set; }
 }
 
-public class PcRunCommand(TypeRegistrar typeRegistrar) : CancellableAsyncCommand<PcRunSettings>
+public class PcRunCommand(TypeRegistrar typeRegistrar, IAnsiConsole console, IBoardStorage boardStorage, IGameService gameService) : CancellableAsyncCommand<PcRunSettings>
 {
 
     public override async Task<int> ExecuteAsync(CommandContext context, PcRunSettings runSettings, CancellationToken cancellationToken)
     {
-        return await RunWebServer(context, cancellationToken);
+        var webTask = RunWebServer(context, cancellationToken);
+
+        if (runSettings.NonInteractive)
+        {
+            await NonInteractiveStrategy(cancellationToken);
+        }
+        else
+        {
+            await StandardStrategy(cancellationToken);
+        }
+
+        return await webTask;
     }
 
-    async Task<int> RunWebServer(CommandContext context, CancellationToken cancellationToken)
+    async Task StandardStrategy(CancellationToken cancellationToken)
+    {
+        bool confirmAsync;
+        do
+        {
+            confirmAsync = await console.ConfirmAsync("Wciśnij enter aby zacząć grę");
+            if (!confirmAsync)
+            {
+                continue;
+            }
+
+            var boards = boardStorage.GetAllAddresses().ToList();
+            if (boards.Count == 0)
+            {
+                console.MarkupLine("[red]Brak dostępnych plansz![/]");
+                continue;
+            }
+
+            console.MarkupLine($"[green]Rozpoczynanie gry dla [/] {boardStorage.Count} graczy");
+            await gameService.StartSessionAsync(cancellationToken);
+        } while (confirmAsync);
+    }
+
+    async Task NonInteractiveStrategy(CancellationToken cancellationToken)
+    {
+        console.MarkupLine("[yellow]Non-interactive mode. Waiting for boards to connect...[/]");
+        var stopwatch = System.Diagnostics.Stopwatch.StartNew();
+        while (!boardStorage.GetAllAddresses().Any() && !cancellationToken.IsCancellationRequested)
+        {
+            if (stopwatch.Elapsed > System.TimeSpan.FromSeconds(30))
+            {
+                console.MarkupLine("[red]Error: Timed out waiting for boards to connect.[/]");
+                return;
+            }
+
+            await Task.Delay(1000, cancellationToken);
+        }
+
+        if (cancellationToken.IsCancellationRequested)
+        {
+            return;
+        }
+
+        console.MarkupLine($"[green]Starting game for [/] {boardStorage.Count} players.");
+        await gameService.StartSessionAsync(cancellationToken);
+    }
+
+    private async Task<int> RunWebServer(CommandContext context, CancellationToken cancellationToken)
     {
         var builder = WebApplication.CreateBuilder(context.Arguments.ToArray());
         foreach (var copyOfService in typeRegistrar.GetCopyOfServices())
         {
-            builder.Services.Add(copyOfService);
+            if (copyOfService.ServiceType == typeof(IBoardStorage))
+            {
+                builder.Services.AddSingleton(boardStorage);
+            }
+            else if (copyOfService.ServiceType == typeof(IGameService))
+            {
+                builder.Services.AddSingleton(gameService);
+            }
+            else
+            {
+                builder.Services.Add(copyOfService);
+            }
         }
 
         builder.Services.AddSingleton<IHostedService, BoardConnectionCheckerService>();

--- a/src/ZtrBoardGame.Console/DependencyInjection/TypeRegistrar.cs
+++ b/src/ZtrBoardGame.Console/DependencyInjection/TypeRegistrar.cs
@@ -44,6 +44,7 @@ public sealed class TypeRegistrar : ITypeRegistrar
         _services.AddSingleton<IUpdateService, UpdateService>();
         _services.AddSingleton(AnsiConsole.Console);
         _services.AddSingleton<IBoardStatusStorage, BoardStatusStorage>();
+        _services.AddSingleton<IGameService, GameService>();
 
         _services.AddSingleton<TypeRegistrar>(this);
 

--- a/tests/ZtrBoardGame.Console.Tests/Features/StepDefinitions/FromPcToBoardStepDefinitions.cs
+++ b/tests/ZtrBoardGame.Console.Tests/Features/StepDefinitions/FromPcToBoardStepDefinitions.cs
@@ -92,7 +92,7 @@ public class FromPcToBoardStepDefinitions
     [Then(@"the PC's console log should contain message like ""(.*)""")]
     public void ThenThePCsConsoleLogShouldContainAnInfoMessageLike(string message)
     {
-        _pcConsole.Lines.Should().Contain(message);
+        _pcConsole.Lines.Should().ContainMatch(message + "*");
     }
     #endregion
 

--- a/tests/ZtrBoardGame.E2E.Tests/docker-compose.yml
+++ b/tests/ZtrBoardGame.E2E.Tests/docker-compose.yml
@@ -1,7 +1,7 @@
 services:
   pc-server:
     build: ../../
-    command: pc run
+    command: pc run --non-interactive
     ports:
       - "${PC_SERVER_PORT}:${PC_SERVER_PORT}"
     environment:


### PR DESCRIPTION
Dodano obsługę sesji gry planszowej, w której plansze mogą komunikować się z serwerem PC.

Zmiany obejmują:
- Dodano usługę `BoardGameService` do zarządzania logiką gry.
- Wprowadzono interfejs `IBoardGameStatusStorage` i jego implementację.
- Dodano kontroler `GameController` do obsługi żądań HTTP do rozpoczęcia gry.
- Rozszerzono kontroler `BoardsController` o endpoint `game/status`.
- Dodano usługę `GameService` do zarządzania sesją gry i rejestracji wyników.
- Zaktualizowano klasę `PcRunCommand` o tryb interaktywny i nieinteraktywny.
- Zaktualizowano plik `docker-compose.yml`, aby uruchamiać serwer PC w trybie nieinteraktywnym.