### PR TITLE
feat(board): add offline mode for board game

### DIFF
--- a/.github/workflows/Create_Velopack_Release.yml
+++ b/.github/workflows/Create_Velopack_Release.yml
@@ -39,7 +39,7 @@ jobs:
             ~/.nuget/packages
           key: ${{ runner.os }}-${{ hashFiles('**/global.json', '**/*.csproj') }}
       - name: 'Run: UnitTests, PublishToGitHubWithVelopack'
-        run: ./build.cmd UnitTests PublishToGitHubWithVelopack
+        run: ./build.cmd UnitTests PublishToGitHubWithVelopack --skip E2ETests UnitTests Format
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   ubuntu-latest:
@@ -57,6 +57,6 @@ jobs:
             ~/.nuget/packages
           key: ${{ runner.os }}-${{ hashFiles('**/global.json', '**/*.csproj') }}
       - name: 'Run: UnitTests, PublishToGitHubWithVelopack'
-        run: ./build.cmd UnitTests PublishToGitHubWithVelopack
+        run: ./build.cmd UnitTests PublishToGitHubWithVelopack --SystemArchitecture arm64 --OperationSystem linux  --skip E2ETests UnitTests Format
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/src/ZtrBoardGame.Configuration.Shared/BoardNetworkSettings.cs
+++ b/src/ZtrBoardGame.Configuration.Shared/BoardNetworkSettings.cs
@@ -1,7 +1,10 @@
+using System;
+
 namespace ZtrBoardGame.Configuration.Shared;
 
 public class BoardNetworkSettings
 {
     public string PcServerAddress { get; set; }
     public string BoardAddress { get; set; }
+    public TimeSpan Timeout { get; set; } = TimeSpan.FromSeconds(10);
 }

--- a/src/ZtrBoardGame.Console/Commands/Board/BoardGameService.cs
+++ b/src/ZtrBoardGame.Console/Commands/Board/BoardGameService.cs
@@ -1,24 +1,17 @@
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
-using Microsoft.Extensions.Logging;
-using Microsoft.Extensions.Options;
 using Spectre.Console;
 using System;
-using System.Net;
-using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
-using ZtrBoardGame.Configuration.Shared;
-using ZtrBoardGame.Console.Infrastructure;
 using ZtrBoardGame.RaspberryPi;
 
 namespace ZtrBoardGame.Console.Commands.Board;
 
-public class BoardGameService(IBoardGameStatusStorage boardGameStatusStorage, IHttpClientFactory httpClientFactory, IAnsiConsole console, IOptions<BoardNetworkSettings> serverAddressProvider,
-    IServiceProvider serviceProvider, ILogger<BoardGameService> logger) : IHostedService
+internal sealed class BoardGameService(IBoardGameStatusStorage boardGameStatusStorage, IAnsiConsole console, IGameStarter gameStarter, IResultSender resultSender, IServiceProvider serviceProvider) : IHostedService, IDisposable
 {
-    private static readonly ResilienceSettings ResilienceSettings = new(10, TimeSpan.FromSeconds(1), "Announce Presence", "the server");
     Task _backgroundTask;
+    private readonly CancellationTokenSource _canceler = new();
 
     public async Task MainGameLoop(CancellationToken cancellationToken)
     {
@@ -30,68 +23,53 @@ public class BoardGameService(IBoardGameStatusStorage boardGameStatusStorage, IH
 
     async Task SingleGame(CancellationToken cancellationToken)
     {
-        await WaitGameToBegin();
+        await WaitGameToBegin(cancellationToken);
+
         using var serviceScope = serviceProvider.CreateScope();
         var gameStrategy = serviceScope.ServiceProvider.GetRequiredService<IGameStrategy>();
-        var delay = await gameStrategy.Do(boardGameStatusStorage.FieldOrder);
+        var delay = await gameStrategy.Do(boardGameStatusStorage.Get().FieldOrder);
 
         await FinishTheGame(cancellationToken, delay);
     }
 
-    async Task WaitGameToBegin()
+    async Task WaitGameToBegin(CancellationToken cancellationToken)
     {
-        do
-        {
-            AnsiConsole.MarkupLine("[yellow]Czekanie na rozpoczęcie gry...[/]");
-            await Task.Delay(TimeSpan.FromSeconds(2));
-        } while (!boardGameStatusStorage.StartGameRequested);
+        await gameStarter.WaitForGameToBeginAsync(cancellationToken);
 
-        AnsiConsole.MarkupLine("[green]Gra rozpoczęta![/]");
-
+        console.MarkupLine("[green]Gra rozpoczęta![/]");
     }
 
     async Task FinishTheGame(CancellationToken cancellationToken, TimeSpan delay)
     {
-        AnsiConsole.MarkupLine("[green]Gra zakończona![/]");
+        console.MarkupLine("[green]Gra zakończona![/]");
 
-        var httpClient = httpClientFactory.CreateClient(BoardHttpClientConfigure.ToPcClientName);
+        await resultSender.SendResultsAsync(delay, cancellationToken);
 
-        using var _ = logger.BeginScopeWith(("PcServerAddress", httpClient.BaseAddress?.ToString() ?? "<NULL>"));
-
-        await ResilienceHelper.InvokeWithRetryAsync(async () =>
-        {
-            await SendResults(cancellationToken, delay, httpClient);
-        }, ResilienceSettings, console, logger, cancellationToken, httpClient.BaseAddress);
-
-        boardGameStatusStorage.StartGameRequested = false;
-    }
-
-    async Task SendResults(CancellationToken cancellationToken, TimeSpan delay, HttpClient httpClient)
-    {
-        if (string.IsNullOrWhiteSpace(serverAddressProvider.Value.BoardAddress))
-        {
-            logger.LogWarning("Local server address is not set. Cannot announce presence to PC server.");
-            throw new InvalidOperationException("Local server address is not set");
-        }
-
-        var urlEncode = WebUtility.UrlEncode(serverAddressProvider.Value.BoardAddress);
-        var resultEncoded = WebUtility.UrlEncode(delay.ToString());
-        var response = await httpClient.PostAsync(
-            $"/api/boards/game/status?responseAddress={urlEncode}&result={resultEncoded}", null,
-            cancellationToken);
-        response.EnsureSuccessStatusCode();
-        console.MarkupLine($"[green]Results sent to the server[/]");
-        logger.LogInformation("Successfully sent results to the server");
+        boardGameStatusStorage.Set(StatusRecord.NotStarted);
     }
 
     public Task StartAsync(CancellationToken cancellationToken)
     {
-        _backgroundTask = MainGameLoop(cancellationToken);
+        _backgroundTask = MainGameLoop(_canceler.Token);
+
+        if (cancellationToken.IsCancellationRequested)
+        {
+            return StopAsync(cancellationToken);
+        }
+
         return Task.CompletedTask;
     }
 
     public async Task StopAsync(CancellationToken cancellationToken)
     {
+        await _canceler.CancelAsync();
+
         await _backgroundTask;
+    }
+
+    public void Dispose()
+    {
+        _backgroundTask.Dispose();
+        _canceler.Dispose();
     }
 }

--- a/src/ZtrBoardGame.Console/Commands/Board/BoardGameStatusStorage.cs
+++ b/src/ZtrBoardGame.Console/Commands/Board/BoardGameStatusStorage.cs
@@ -4,12 +4,38 @@ namespace ZtrBoardGame.Console.Commands.Board;
 
 public interface IBoardGameStatusStorage
 {
-    bool StartGameRequested { get; set; }
-    FieldOrder FieldOrder { get; set; }
+    public StatusRecord Get();
+    public void Set(StatusRecord status);
+}
+
+public record StatusRecord
+{
+    private StatusRecord(bool StartGameRequested, FieldOrder FieldOrder)
+    {
+        this.StartGameRequested = StartGameRequested;
+        this.FieldOrder = FieldOrder;
+    }
+
+    public bool StartGameRequested { get; }
+    public FieldOrder FieldOrder { get; }
+
+    public static StatusRecord NotStarted => new(false, null);
+    public static StatusRecord Started(FieldOrder fieldOrder) => new(true, fieldOrder);
+
+    public void Deconstruct(out bool StartGameRequested, out FieldOrder FieldOrder)
+    {
+        StartGameRequested = this.StartGameRequested;
+        FieldOrder = this.FieldOrder;
+    }
 }
 
 public class BoardGameStatusStorage : IBoardGameStatusStorage
 {
-    public bool StartGameRequested { get; set; }
-    public FieldOrder FieldOrder { get; set; }
+    private StatusRecord _status = StatusRecord.NotStarted;
+
+    public StatusRecord Get()
+        => _status;
+
+    public void Set(StatusRecord status)
+        => _status = status;
 }

--- a/src/ZtrBoardGame.Console/Commands/Board/BuildConfigurationStrategy.cs
+++ b/src/ZtrBoardGame.Console/Commands/Board/BuildConfigurationStrategy.cs
@@ -1,0 +1,62 @@
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.HttpOverrides;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using ZtrBoardGame.Console.Commands.Board.Offline;
+using ZtrBoardGame.Console.Commands.Board.Online;
+
+namespace ZtrBoardGame.Console.Commands.Board;
+
+static class BuildConfigurationStrategy
+{
+    public static IConfigurationStrategy GetStrategy(bool runInOfflineMode)
+    {
+        if (runInOfflineMode)
+        {
+            return new OfflineConfigurationStrategy();
+        }
+        else
+        {
+            return new OnlineConfigurationStrategy();
+        }
+    }
+}
+interface IConfigurationStrategy
+{
+    void ConfigureServices(WebApplicationBuilder builder);
+    void ConfigureApp(WebApplication app);
+}
+
+class OfflineConfigurationStrategy : IConfigurationStrategy
+{
+    public void ConfigureServices(WebApplicationBuilder builder)
+    {
+        builder.Services.AddSingleton<IGameStarter, OfflineGameStarter>();
+        builder.Services.AddSingleton<IResultSender, OfflineResultSender>();
+    }
+    public void ConfigureApp(WebApplication app)
+    {
+        // No specific app configuration needed for offline mode
+    }
+}
+
+class OnlineConfigurationStrategy : IConfigurationStrategy
+{
+    public void ConfigureServices(WebApplicationBuilder builder)
+    {
+        builder.Services.AddSingleton<IHostedService, HelloService>();
+        builder.Services.AddSingleton<IResultSender, OnlineResultSender>();
+        builder.Services.AddSingleton<IGameStarter, OnlineGameStarter>();
+        builder.Services.AddControllers();
+        builder.Services.AddHttpClient();
+        builder.Services.Configure<ForwardedHeadersOptions>(options =>
+        {
+            options.ForwardedHeaders = ForwardedHeaders.XForwardedFor | ForwardedHeaders.XForwardedProto;
+        });
+    }
+    public void ConfigureApp(WebApplication app)
+    {
+        app.UseForwardedHeaders();
+        app.MapControllers();
+    }
+}

--- a/src/ZtrBoardGame.Console/Commands/Board/IGameStarter.cs
+++ b/src/ZtrBoardGame.Console/Commands/Board/IGameStarter.cs
@@ -1,0 +1,9 @@
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace ZtrBoardGame.Console.Commands.Board;
+
+public interface IGameStarter
+{
+    public Task WaitForGameToBeginAsync(CancellationToken cancellationToken);
+}

--- a/src/ZtrBoardGame.Console/Commands/Board/IResultSender.cs
+++ b/src/ZtrBoardGame.Console/Commands/Board/IResultSender.cs
@@ -1,0 +1,10 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace ZtrBoardGame.Console.Commands.Board;
+
+public interface IResultSender
+{
+    public Task SendResultsAsync(TimeSpan delay, CancellationToken cancellationToken);
+}

--- a/src/ZtrBoardGame.Console/Commands/Board/Offline/OfflineGameStarter.cs
+++ b/src/ZtrBoardGame.Console/Commands/Board/Offline/OfflineGameStarter.cs
@@ -1,0 +1,23 @@
+using Spectre.Console;
+using System;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace ZtrBoardGame.Console.Commands.Board.Offline;
+
+class OfflineGameStarter(IAnsiConsole console, IBoardGameStatusStorage boardGameStatusStorage) : IGameStarter
+{
+    private const int FieldsOnBoard = 16;
+    private const int FieldsInPlay = 4;
+    public async Task WaitForGameToBeginAsync(CancellationToken cancellationToken)
+    {
+        var _ = await console.ConfirmAsync("[yellow]Naciśnij dowolny klawisz, aby rozpocząć grę...[/]", cancellationToken: cancellationToken);
+
+        var list = Enumerable.Range(0, FieldsOnBoard)
+            .OrderBy(_ => Random.Shared.Next())
+            .Take(FieldsInPlay)
+            .ToList();
+        boardGameStatusStorage.Set(StatusRecord.Started(new(list)));
+    }
+}

--- a/src/ZtrBoardGame.Console/Commands/Board/Offline/OfflineResultSender.cs
+++ b/src/ZtrBoardGame.Console/Commands/Board/Offline/OfflineResultSender.cs
@@ -1,0 +1,15 @@
+using Spectre.Console;
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace ZtrBoardGame.Console.Commands.Board.Offline;
+
+class OfflineResultSender(IAnsiConsole console) : IResultSender
+{
+    public Task SendResultsAsync(TimeSpan delay, CancellationToken cancellationToken)
+    {
+        console.MarkupLine($"[yellow]Your result: {delay}[/]");
+        return Task.CompletedTask;
+    }
+}

--- a/src/ZtrBoardGame.Console/Commands/Board/Online/BoardStatusStorage.cs
+++ b/src/ZtrBoardGame.Console/Commands/Board/Online/BoardStatusStorage.cs
@@ -1,4 +1,4 @@
-namespace ZtrBoardGame.Console.Commands.Board;
+namespace ZtrBoardGame.Console.Commands.Board.Online;
 
 public interface IBoardStatusStorage
 {

--- a/src/ZtrBoardGame.Console/Commands/Board/Online/GameController.cs
+++ b/src/ZtrBoardGame.Console/Commands/Board/Online/GameController.cs
@@ -1,9 +1,8 @@
 using Microsoft.AspNetCore.Mvc;
 using System;
 using System.Linq;
-using ZtrBoardGame.RaspberryPi;
 
-namespace ZtrBoardGame.Console.Commands.Board;
+namespace ZtrBoardGame.Console.Commands.Board.Online;
 
 [ApiController, Route("api/board/game")]
 public class GameController(IBoardGameStatusStorage boardGameStatusStorage) : ControllerBase
@@ -12,8 +11,7 @@ public class GameController(IBoardGameStatusStorage boardGameStatusStorage) : Co
     public IActionResult Post()
     {
         var list = Enumerable.Range(0, 16).OrderBy(_ => Random.Shared.Next()).Take(4).ToList();
-        boardGameStatusStorage.FieldOrder = new FieldOrder(list);
-        boardGameStatusStorage.StartGameRequested = true;
+        boardGameStatusStorage.Set(StatusRecord.Started(new(list)));
         return Ok();
     }
 }

--- a/src/ZtrBoardGame.Console/Commands/Board/Online/HealthController.cs
+++ b/src/ZtrBoardGame.Console/Commands/Board/Online/HealthController.cs
@@ -2,7 +2,7 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
 using Spectre.Console;
 
-namespace ZtrBoardGame.Console.Commands.Board;
+namespace ZtrBoardGame.Console.Commands.Board.Online;
 
 [ApiController]
 [Route("api/board/health")]

--- a/src/ZtrBoardGame.Console/Commands/Board/Online/OnlineGameStarter.cs
+++ b/src/ZtrBoardGame.Console/Commands/Board/Online/OnlineGameStarter.cs
@@ -1,0 +1,18 @@
+using Spectre.Console;
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace ZtrBoardGame.Console.Commands.Board.Online;
+
+class OnlineGameStarter(IAnsiConsole console, IBoardGameStatusStorage boardGameStatusStorage) : IGameStarter
+{
+    public async Task WaitForGameToBeginAsync(CancellationToken cancellationToken)
+    {
+        do
+        {
+            console.MarkupLine("[yellow]Czekanie na rozpoczêcie gry przez serwer...[/]");
+            await Task.Delay(TimeSpan.FromSeconds(2), cancellationToken);
+        } while (!boardGameStatusStorage.Get().StartGameRequested);
+    }
+}

--- a/src/ZtrBoardGame.Console/Commands/Board/Online/OnlineResultSender.cs
+++ b/src/ZtrBoardGame.Console/Commands/Board/Online/OnlineResultSender.cs
@@ -1,0 +1,47 @@
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Spectre.Console;
+using System;
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using ZtrBoardGame.Configuration.Shared;
+using ZtrBoardGame.Console.Infrastructure;
+
+namespace ZtrBoardGame.Console.Commands.Board.Online;
+
+class OnlineResultSender(IAnsiConsole console, IHttpClientFactory httpClientFactory, IOptions<BoardNetworkSettings> serverAddressProvider, ILogger<OnlineResultSender> logger) : IResultSender
+{
+    private static readonly ResilienceSettings ResilienceSettings = new(10, TimeSpan.FromSeconds(1), "Announce Presence", "the server");
+
+    public async Task SendResultsAsync(TimeSpan delay, CancellationToken cancellationToken)
+    {
+        var httpClient = httpClientFactory.CreateClient(BoardHttpClientConfigure.ToPcClientName);
+
+        using var _ = logger.BeginScopeWith(("PcServerAddress", httpClient.BaseAddress?.ToString() ?? "<NULL>"));
+
+        await ResilienceHelper.InvokeWithRetryAsync(async () =>
+        {
+            await SendResults(cancellationToken, delay, httpClient);
+        }, ResilienceSettings, console, logger, cancellationToken, httpClient.BaseAddress);
+    }
+
+    async Task SendResults(CancellationToken cancellationToken, TimeSpan delay, HttpClient httpClient)
+    {
+        if (string.IsNullOrWhiteSpace(serverAddressProvider.Value.BoardAddress))
+        {
+            logger.LogWarning("Local server address is not set. Cannot announce presence to PC server.");
+            throw new InvalidOperationException("Local server address is not set");
+        }
+
+        var urlEncode = WebUtility.UrlEncode(serverAddressProvider.Value.BoardAddress);
+        var resultEncoded = WebUtility.UrlEncode(delay.ToString());
+        var response = await httpClient.PostAsync(
+            $"/api/boards/game/status?responseAddress={urlEncode}&result={resultEncoded}", null,
+            cancellationToken);
+        response.EnsureSuccessStatusCode();
+        console.MarkupLine($"[green]Results sent to the server[/]");
+        logger.LogInformation("Successfully sent results to the server");
+    }
+}

--- a/src/ZtrBoardGame.Console/DependencyInjection/TypeRegistrar.cs
+++ b/src/ZtrBoardGame.Console/DependencyInjection/TypeRegistrar.cs
@@ -7,7 +7,7 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.IO;
 using ZtrBoardGame.Configuration.Shared;
-using ZtrBoardGame.Console.Commands.Board;
+using ZtrBoardGame.Console.Commands.Board.Online;
 using ZtrBoardGame.Console.Commands.PC;
 using ZtrBoardGame.Console.Infrastructure;
 using ZtrBoardGame.RaspberryPi;

--- a/src/ZtrBoardGame.Console/appsettings.E2E.json
+++ b/src/ZtrBoardGame.Console/appsettings.E2E.json
@@ -1,7 +1,4 @@
 {
-  "BoardNetworkSettings": {
-    "PcServerAddress": "http://localhost:8080"
-  },
   "Serilog": {
     "MinimumLevel": {
       "Default": "Verbose"

--- a/src/ZtrBoardGame.Console/appsettings.json
+++ b/src/ZtrBoardGame.Console/appsettings.json
@@ -4,10 +4,6 @@
     "UseGitHubSource": true,
     "FetchPrereleases": true
   },
-  "BoardNetworkSettings": {
-    "PcServerAddress": "http://localhost:8080",
-    "BoardAddress":  "http://localhost:5000"
-  },
   "PhysicalBoardSettings": {
     "Addresses": [ "0x20", "0x21", "0x22", "0x23" ],
     "InterruptPinNumber": 4

--- a/tests/ZtrBoardGame.Console.Tests/Features/StepDefinitions/FromBoardToPcStepDefinitions.cs
+++ b/tests/ZtrBoardGame.Console.Tests/Features/StepDefinitions/FromBoardToPcStepDefinitions.cs
@@ -8,7 +8,7 @@ using Spectre.Console;
 using Spectre.Console.Testing;
 using System.Net;
 using ZtrBoardGame.Configuration.Shared;
-using ZtrBoardGame.Console.Commands.Board;
+using ZtrBoardGame.Console.Commands.Board.Online;
 
 namespace ZtrBoardGame.Console.Tests.Features.StepDefinitions;
 

--- a/tests/ZtrBoardGame.Console.Tests/Features/StepDefinitions/FromPcToBoardStepDefinitions.cs
+++ b/tests/ZtrBoardGame.Console.Tests/Features/StepDefinitions/FromPcToBoardStepDefinitions.cs
@@ -7,6 +7,7 @@ using Spectre.Console;
 using Spectre.Console.Testing;
 using ZtrBoardGame.Configuration.Shared;
 using ZtrBoardGame.Console.Commands.Board;
+using ZtrBoardGame.Console.Commands.Board.Online;
 using ZtrBoardGame.Console.Commands.PC;
 using ZtrBoardGame.Console.Tests.Infrastructure;
 using ZtrBoardGame.RaspberryPi;


### PR DESCRIPTION
- Introduced offline mode for board (no HTTP server, no PC communication)
- Added `--no-server` option to BoardRunCommand to enable offline mode
- Split configuration into online (with HTTP) and offline strategies
- In offline mode: game starts on user confirmation, result shown locally
- Refactored interfaces: added IGameStarter and IResultSender with separate implementations for each mode
- Changed game status storage to use StatusRecord
- Moved HTTP/server-related classes to .Online namespace
- Simplified game start/result logic depending on mode