### PR TITLE
feat: Implement missing server address failure scenario

### DIFF
--- a/src/ZtrBoardGame.Configuration.Shared/PhysicalBoardSettings.cs
+++ b/src/ZtrBoardGame.Configuration.Shared/PhysicalBoardSettings.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace ZtrBoardGame.Configuration.Shared;
+
+public class PhysicalBoardSettings
+{
+    public IReadOnlyCollection<string> Addresses { get; set; } = new List<string>(); // for example 0x20, 0x21, 0x22, 0x23
+    public int InterruptPinNumber { get; set; } = 4; // Usually 4
+    public int FieldsInPlay { get; set; } = 4; // Usually 4
+    public int AmountOfFieldsPerAddressableBoard { get; set; } = 4;
+    public IEnumerable<int> GetAddressesAsInt()
+        => Addresses.Select(x => Convert.ToInt32(x.Trim(), 16));
+
+    public int AmountOfFields()
+        => Addresses.Count * AmountOfFieldsPerAddressableBoard;
+}

--- a/src/ZtrBoardGame.Console/Commands/Board/Offline/OfflineGameStarter.cs
+++ b/src/ZtrBoardGame.Console/Commands/Board/Offline/OfflineGameStarter.cs
@@ -1,22 +1,22 @@
+using Microsoft.Extensions.Options;
 using Spectre.Console;
 using System;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using ZtrBoardGame.Configuration.Shared;
 
 namespace ZtrBoardGame.Console.Commands.Board.Offline;
 
-class OfflineGameStarter(IAnsiConsole console, IBoardGameStatusStorage boardGameStatusStorage) : IGameStarter
+class OfflineGameStarter(IAnsiConsole console, IBoardGameStatusStorage boardGameStatusStorage, IOptions<PhysicalBoardSettings> options) : IGameStarter
 {
-    private const int FieldsOnBoard = 16;
-    private const int FieldsInPlay = 4;
     public async Task WaitForGameToBeginAsync(CancellationToken cancellationToken)
     {
         var _ = await console.ConfirmAsync("[yellow]Naciśnij dowolny klawisz, aby rozpocząć grę...[/]", cancellationToken: cancellationToken);
 
-        var list = Enumerable.Range(0, FieldsOnBoard)
+        var list = Enumerable.Range(0, options.Value.AmountOfFields())
             .OrderBy(_ => Random.Shared.Next())
-            .Take(FieldsInPlay)
+            .Take(options.Value.FieldsInPlay)
             .ToList();
         boardGameStatusStorage.Set(StatusRecord.Started(new(list)));
     }

--- a/src/ZtrBoardGame.RaspberryPi/HardwareAccess/I2CPhysicalBoard.cs
+++ b/src/ZtrBoardGame.RaspberryPi/HardwareAccess/I2CPhysicalBoard.cs
@@ -1,20 +1,12 @@
 ﻿using Microsoft.Extensions.Options;
 using System.Device.Gpio;
+using ZtrBoardGame.Configuration.Shared;
 
 namespace ZtrBoardGame.RaspberryPi.HardwareAccess;
 
 interface IPhysicalBoard
 {
     public IEnumerable<IField> GetFields();
-}
-
-class PhysicalBoardSettings
-{
-    public IReadOnlyCollection<string> Addresses { get; set; } = new List<string>(); // for example 0x20, 0x21, 0x22, 0x23
-    public int InterruptPinNumber { get; set; } // Usually 4
-
-    public IEnumerable<int> GetAddressesAsInt()
-        => Addresses.Select(x => Convert.ToInt32(x.Trim(), 16));
 }
 
 #pragma warning disable S101

--- a/src/ZtrBoardGame.RaspberryPi/RaspberryPiDependenciesInstaller.cs
+++ b/src/ZtrBoardGame.RaspberryPi/RaspberryPiDependenciesInstaller.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using ZtrBoardGame.Configuration.Shared;
 using ZtrBoardGame.RaspberryPi.HardwareAccess;
 
 namespace ZtrBoardGame.RaspberryPi;

--- a/src/ZtrBoardGame.RaspberryPi/ZtrBoardGame.RaspberryPi.csproj
+++ b/src/ZtrBoardGame.RaspberryPi/ZtrBoardGame.RaspberryPi.csproj
@@ -15,4 +15,8 @@
     <PackageReference Include="System.Device.Gpio" Version="4.0.1" />
   </ItemGroup>
 
+  <ItemGroup>
+    <ProjectReference Include="..\ZtrBoardGame.Configuration.Shared\ZtrBoardGame.Configuration.Shared.csproj" />
+  </ItemGroup>
+
 </Project>


### PR DESCRIPTION
Extract PhysicalBoardSettings to ZtrBoardGame.Configuration.Shared

- Moved PhysicalBoardSettings to a new shared project for reuse across the solution
- Added project reference to ZtrBoardGame.Configuration.Shared in ZtrBoardGame.RaspberryPi
- Updated I2CPhysicalBoard.cs to use the shared PhysicalBoardSettings instead of a local definition
- Enhanced PhysicalBoardSettings with properties and helper methods for board configuration
- Refactored OfflineGameStarter.cs to use IOptions<PhysicalBoardSettings> for dynamic board settings
- Unified and simplified board settings usage, removing duplication and improving configurability