### PR TITLE
🎨 feat: add application icon to console project

### DIFF
--- a/src/ZtrBoardGame.Console/ZtrBoardGame.Console.csproj
+++ b/src/ZtrBoardGame.Console/ZtrBoardGame.Console.csproj
@@ -6,6 +6,7 @@
     <OutputType>Exe</OutputType>
     <Nullable>enable</Nullable>
     <SelfContained>true</SelfContained>
+    <ApplicationIcon>applogo.ico</ApplicationIcon>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Dodano ikonę aplikacji do projektu ZtrBoardGame.Console.csproj:

- ustawiono atrybut `<ApplicationIcon>` na plik `applogo.ico`